### PR TITLE
Explicitly enable PasswordAuthentication for Amazon Linux

### DIFF
--- a/amazon_linux.dockerfile
+++ b/amazon_linux.dockerfile
@@ -11,7 +11,9 @@ RUN if [ "$UPDATED" = true ]; then yum upgrade -y; fi \
     && echo "demo" | passwd --stdin demo \
     && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" \
     && ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" \
-    && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""
+    && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" \
+    # Explicitly enable PasswordAuthentication
+    && sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_config
 
 CMD [ "/usr/sbin/sshd", "-D" ]
 


### PR DESCRIPTION
**What**:
This PR explicitly enables PasswordAuthentication for Amazon Linux (and adds a newline at the end).

**Why**:
Because I noticed that one cannot login via SSH, because of
```
docker run --rm ghcr.io/greenbone/vt-test-environments/amazon_linux:1 bash -c "cat /etc/ssh/sshd_config | grep Password"
PasswordAuthentication no
```
This only affects Amazon Linux 1 and not 2 and 2022.

**How**:
With this patch applied, the `sshd_config` says
```
docker run --rm ghcr.io/greenbone/vt-test-environments/amazon_linux:1 bash -c "cat /etc/ssh/sshd_config | grep Password"
PasswordAuthentication yes
```
and logging in via SSH is possible again.