### PR TITLE
Add original source tag reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Environments for VT testing
 Each Docker image comes with a pre-installed SSH server and a demo user (password: demo). This enables a VT developer to deploy a clean test environment within seconds.
 
 # Available images & tags
-- Alma Linux (`alma_linux`)
+- [Alma Linux](https://hub.docker.com/_/almalinux/tags) (`alma_linux`)
     - `8.5`
     - `8.6`
     - `9.0`
-- Amazon Linux (`amazon_linux`)
+- [Amazon Linux](https://hub.docker.com/_/amazonlinux/tags) (`amazon_linux`)
     - `1`
     - `2`
     - `2022`
-- Debian Linux (`debian_linux`)
+- [Debian Linux](https://hub.docker.com/_/debian/tags) (`debian_linux`)
     - `woody`
     - `sarge`
     - `etch`
@@ -23,19 +23,20 @@ Each Docker image comes with a pre-installed SSH server and a demo user (passwor
     - `stretch`
     - `buster`
     - `bullseye`
-- Mageia Linux (`mageia_linux`)
+- [Mageia Linux](https://hub.docker.com/_/mageia/tags) (`mageia_linux`)
     - `7`
     - `8`
-- Oracle Linux (`oracle_linux`)
+- [Oracle Linux](https://hub.docker.com/_/oraclelinux/tags) (`oracle_linux`)
     - `5`
     - `6`
     - `7`
     - `8`
     - `9`
-- Rocky Linux (`rocky_linux`)
+- [Rocky Linux](https://hub.docker.com/_/rockylinux/tags) (`rocky_linux`)
     - `8.5`
     - `8.6`
     - `9.0`
+- [Slackware Linux](https://hub.docker.com/r/vbatts/slackware/tags) (`slackware_linux`)
     - `13.0`
     - `13.37`
     - `14.0`


### PR DESCRIPTION
**What**:

Converted the headings in `Available images & tags` to links that point toward their respective docker tag pages.

**Why**:

Since the docker files can accept arbitrary tags as a parameter, we can pass all the tags the original docker images offer for our testing. 

To make this a bit easier to access, I propose to directly link to respective docker tag pages.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
