### PR TITLE
Use Docker Hub for Oracle & add Oracle Linux 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,9 @@ jobs:
           - DOCKERFILE: oracle_linux
             BASEIMAGE: oraclelinux
             TAG: "8"
+          - DOCKERFILE: oracle_linux
+            BASEIMAGE: oraclelinux
+            TAG: "9"
           - DOCKERFILE: rocky_linux
             BASEIMAGE: rockylinux
             TAG: "8.5"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each Docker image comes with a pre-installed SSH server and a demo user (passwor
     - `6`
     - `7`
     - `8`
+    - `9`
 - Rocky Linux (`rocky_linux`)
     - `8.5`
 - Slackware Linux (`slackware_linux`)


### PR DESCRIPTION
**What**:
This PR switches from Oracle Registry to Docker Hub for Oracle images and adds support for Oracle Linux 9.

**Why**:

- Because there seems to be no reason to not use Docker Hub (the only difference is the shasum of the Oracle Linux 6 image, everything else is identical)
- To have Oracle Linux 9 available for testing

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
