### PR TITLE
Fix build of Slackware current

### DIFF
--- a/slackware_linux.dockerfile
+++ b/slackware_linux.dockerfile
@@ -6,7 +6,8 @@ ARG UPDATED=true
 
 RUN echo "Y" | slackpkg update \
     # When updating, we need to upgrade slackpkg itself first. Otherwise upgrade-all will abort
-    && if [ "$UPDATED" = true ]; then slackpkg upgrade slackpkg && slackpkg upgrade-all; fi \
+    # We can skip this step, if slackpkg is already up-to-date
+    && if [ "$UPDATED" = true ]; then slackpkg upgrade slackpkg || slackpkg upgrade-all; fi \
     && slackpkg install openssh \
     && rm -rf /var/lib/slackpkg/* \
     && useradd demo \


### PR DESCRIPTION
**What**:
This PR fixes the build of Slackware current.

**Why**:
`vbatts/slackware:current` has been updated to include the latest version of `slackpkg`. Because in https://github.com/greenbone/vt-test-environments/runs/7997468735?check_suite_focus=true it was tired to update `slackpkg` anyways, the step failed. Hence we can make updating it optionally.

**How**:
Built the images for current, 14.2 and 13.0 locally and ran it to confirm it works.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
