### PR TITLE
Add EulerOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,20 @@ jobs:
             TAG: buster
           - CONTEXT: operating_systems/debian_linux
             TAG: bullseye
+          - CONTEXT: operating_systems/euleros_linux
+            TAG: "2.0"
+          - CONTEXT: operating_systems/euleros_linux
+            TAG: "2.1"
+          - CONTEXT: operating_systems/euleros_linux
+            TAG: "2.2"
+          - CONTEXT: operating_systems/euleros_linux
+            TAG: "2.3"
+          - CONTEXT: operating_systems/euleros_linux
+            TAG: "2.5"
+          - CONTEXT: operating_systems/euleros_linux
+            TAG: "2.9"
+          - CONTEXT: operating_systems/euleros_linux
+            TAG: "2.10"
           - CONTEXT: operating_systems/mageia_linux
             TAG: "7"
           - CONTEXT: operating_systems/mageia_linux

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Each Docker image comes with a pre-installed SSH server and a demo user (passwor
     - `stretch`
     - `buster`
     - `bullseye`
+- EulerOS Linux (`euleros_linux`)
+    - `2.0`
+    - `2.1`
+    - `2.2`
+    - `2.3`
+    - `2.5`
+    - `2.9`
+    - `2.10`
 - [Mageia Linux](https://hub.docker.com/_/mageia/tags) (`mageia_linux`)
     - `7`
     - `8`

--- a/operating_systems/euleros_linux/Dockerfile
+++ b/operating_systems/euleros_linux/Dockerfile
@@ -1,0 +1,43 @@
+# Don't use anything RHEL 9-based. It'll break the RPM GPG key.
+FROM rockylinux:8.6 as builder
+
+ARG TAG
+WORKDIR /tmp
+
+# Prepare environment
+RUN mkdir -p rootfs/etc/yum.repos.d/
+COPY EulerOS-base.repo rootfs/etc/yum.repos.d/
+
+# Install packages (note the GPG key for EulerOS 2.0 seems to be broken, hence disabling it
+# and we pin the releasever here, because it interferes with the yum installation)
+RUN yum --installroot=/tmp/rootfs install --releasever $TAG \
+    -y $([ "$TAG" = "2.0" ] && echo "--nogpgcheck") \
+    openssh-server rootfiles yum
+
+# Remove sometimes newly installed, but broken repofile
+RUN rm rootfs/etc/yum.repos.d/EulerOS-base.repo.rpmnew || true
+# Cleanup
+RUN yum --installroot=/tmp/rootfs clean all \
+    && rm -rf /var/cache/yum
+# Removing other languages saves us ~100 MB
+RUN localedef --prefix rootfs/ --delete-from-archive $(localedef --list-archive --prefix rootfs | grep -va "en_US.utf8") \
+    && mv rootfs/usr/lib/locale/locale-archive rootfs/usr/lib/locale/locale-archive.tmpl \
+    && chroot rootfs/ build-locale-archive
+
+FROM scratch
+ARG TAG
+COPY --from=builder /tmp/rootfs/ /
+
+# Pin releasever
+RUN echo "${TAG}" > /etc/yum/vars/releasever \
+    # Add demo user
+    && useradd demo \
+    && echo "demo:demo" | chpasswd \
+    # Generate SSH keys
+    && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" \
+    && ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" \
+    && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""
+
+CMD [ "/usr/sbin/sshd", "-D" ]
+
+EXPOSE 22

--- a/operating_systems/euleros_linux/EulerOS-base.repo
+++ b/operating_systems/euleros_linux/EulerOS-base.repo
@@ -1,0 +1,6 @@
+[EulerOS-base]
+name=EulerOS-base
+baseurl=https://mirrors.huaweicloud.com/euler/$releasever/os/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=https://mirrors.huaweicloud.com/euler/$releasever/os/RPM-GPG-KEY-EulerOS


### PR DESCRIPTION
**What**:
This PR adds EulerOS.

Part of https://jira.greenbone.net/browse/VTD-1774.
Depends on https://github.com/greenbone/vt-test-environments/pull/18.

**Why**:
To have EulerOS available for testing.
Compared to the other images, this one is different, because we don't use the official EulerOS images on [Docker Hub](https://hub.docker.com/_/euleros/?tab=tags), but build is from scratch.
Inspired by the [official build tool](https://github.com/euleros/euleros-docker-images).
Building one image takes 2 - 5 min. (50% of the time for downloading ~100 MB)

**How**:
Built all images for the available EulerOS releases and checked that
- `yum list installed` is working
- `yum update` is working and doesn't report any updates
- `/etc/os-release` & `/etc/euleros-release` contains the correct information

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
