### PR TITLE
Add AlmaLinux 8.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
       matrix:
         include:
           - CONTEXT: operating_systems/almalinux
+            TAG: "8.4"
+          - CONTEXT: operating_systems/almalinux
             TAG: "8.5"
           - CONTEXT: operating_systems/almalinux
             TAG: "8.6"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ However, please use `docker exec -it target bash` preferrebly to interact with t
 When done, the container can be stopped with `docker stop target`.
 ## Available images & tags
 - [AlmaLinux](https://ghcr.io/greenbone/vt-test-environments/almalinux) (`almalinux`)
+    - `8.4`
     - `8.5`
     - `8.6`
     - `9.0`


### PR DESCRIPTION
**What**:
This PR adds AlmaLinux 8.4.

**Why**:
To have it available for testing.
Note that the AlmaLinux 8.3 repo is still working too, but there's no base image on Docker Hub, so some additional work would be required to get it working as well.

**How**:
Spun up a container using this image, ran `dnf update` to check for any updates, checked `/etc/os-release` for the correct content, SSH'ed into the container using the demo account