### PR TITLE
Add AlmaLinux 8.7 and 9.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,11 @@ jobs:
           - CONTEXT: operating_systems/almalinux
             TAG: "8.6"
           - CONTEXT: operating_systems/almalinux
+            TAG: "8.7"
+          - CONTEXT: operating_systems/almalinux
             TAG: "9.0"
+          - CONTEXT: operating_systems/almalinux
+            TAG: "9.1"
           - CONTEXT: operating_systems/amazonlinux
             TAG: "1"
           - CONTEXT: operating_systems/amazonlinux

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ When done, the container can be stopped with `docker stop target`.
     - `8.4`
     - `8.5`
     - `8.6`
+    - `8.7`
     - `9.0`
+    - `9.1`
 - [Amazon Linux](https://ghcr.io/greenbone/vt-test-environments/amazonlinux) (`amazonlinux`)
     - `1`
     - `2`


### PR DESCRIPTION
**What**:
This PR adds AlmaLinux 8.7 and 9.1.

**Why**:
To have them available for testing.

**How**:
Built both images, confirmed that the dnf update / install is working, ssh'ed into them and checked `/etc/os-release` for correct release.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
