### PR TITLE
Add script for running all test environments

### DIFF
--- a/tools/run_all.sh
+++ b/tools/run_all.sh
@@ -1,0 +1,39 @@
+#!/bin/env bash
+set -e
+
+trap "docker kill target &> /dev/null || docker rm target &> /dev/null" SIGINT
+
+repo="ghcr.io/greenbone/vt-test-environments"
+name=$1
+command=${*:2}
+
+if [[ -z $name ]]
+then
+    echo "$0: Run all test environments"
+    echo "Usage: $0 IMAGE [command ...]"
+    echo ""
+    echo "Examples:"
+    echo "Run \"dpkg --version\" it every Ubuntu environment:"
+    echo -e "\t$0 ubuntu dpkg --version"
+    echo "Run every Debian environment for scanning via SSH, one after another:"
+    echo -e "\t $0 debian"
+    exit 1
+fi
+
+echo ">> Pulling all $name images"
+docker pull -a "$repo/$name"
+images=$(docker images "$repo/$name" --format "{{ .Repository }}:{{ .Tag }}" | grep -v ":<none>$")
+
+for image in $images
+do
+    echo ">> Running $image"
+    if [[ -z $command ]]
+    then
+        docker run -p 2222:22 --name target -d "$image"
+        read -p ">> Press enter to stop container and continue with next one"
+        docker kill target > /dev/null
+    else
+        docker run --name target -it "$image" $command
+    fi
+    docker rm target > /dev/null
+done


### PR DESCRIPTION
**What**:
This PR adds a script to run all images of an OS easily.

**Why**:
Instead of looking up the tags of available images, manually starting and stopping then, this script will take care of it. This eases testing a change in multiple environments (e.g. all Ubuntu images).
The script provides to modes: One for executing a specific command in all environments and another for only starting the container to have it available for SSH-based scanning.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] CHANGELOG.md entry
- [ ] Documentation
