### PR TITLE
Add Red Hat Enterprise Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,62 @@ jobs:
             TAG: "8"
           - CONTEXT: operating_systems/oraclelinux
             TAG: "9"
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi7
+            TAG: "7.6"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi7
+            TAG: "7.7"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi7
+            TAG: "7.8"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi7
+            TAG: "7.9"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi8
+            TAG: "8.0"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi8
+            TAG: "8.1"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi8
+            TAG: "8.2"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi8
+            TAG: "8.3"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi8
+            TAG: "8.4"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi8
+            TAG: "8.5"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi8
+            TAG: "8.6"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi8
+            TAG: "8.7"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi9
+            TAG: "9.0.0"
+            UPDATED: false
+          - CONTEXT: operating_systems/rhel
+            BASEIMAGE: registry.access.redhat.com/ubi9
+            TAG: "9.1.0"
+            UPDATED: false
           - CONTEXT: operating_systems/rockylinux
             TAG: "8.5"
           - CONTEXT: operating_systems/rockylinux

--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ When done, the container can be stopped with `docker stop target`.
     - `7`
     - `8`
     - `9`
+- [Red Hat Enterprise Linux](https://ghcr.io/greenbone/vt-test-environments/rhel) (`rhel`)
+    - `7.6`
+    - `7.7`
+    - `7.8`
+    - `7.9`
+    - `8.0`
+    - `8.1`
+    - `8.2`
+    - `8.3`
+    - `8.4`
+    - `8.5`
+    - `8.6`
+    - `8.7`
+    - `9.0.0`
+    - `9.1.0`
 - [Rocky Linux](https://ghcr.io/greenbone/vt-test-environments/rockylinux) (`rockylinux`)
     - `8.5`
     - `8.6`

--- a/operating_systems/rhel/Dockerfile
+++ b/operating_systems/rhel/Dockerfile
@@ -1,0 +1,22 @@
+ARG BASEIMAGE
+ARG TAG
+
+FROM ${BASEIMAGE}:${TAG}
+ARG UPDATED=false
+ARG TAG
+
+RUN if [ "$UPDATED" = true ]; then \
+    # Pinning minor version is impossible because of missing separate repository.
+    # Workaround: Exclude release files (e.g. /etc/os-release)
+    # for RHEL 7 and RHEL 8 or higher, respectively
+    yum upgrade -y --exclude redhat-release-server --exclude redhat-release \
+    && yum clean all; \
+    fi \
+    && yum install -y openssh-server \
+    && useradd demo \
+    && echo "demo" | passwd --stdin demo \
+    && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" \
+    && ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" \
+    && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""
+
+CMD [ "/usr/sbin/sshd", "-D" ]


### PR DESCRIPTION
## What
This PR adds Red Hat Enterprise Linux 7.6 through 7.9, 8.0 through 8.7 as well as 9.0.0 and 9.1.0.

## Why
To have them available for testing.

## References

<!-- Add links to issue tickets, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


