### PR TITLE
Fix output in container test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,7 +200,7 @@ jobs:
             -o "KexAlgorithms $(ssh -Q kex | tr '\n' ',' | head -c -1)" \
             -o "Ciphers $(ssh -Q ciphers | tr '\n' ',' | head -c -1)" \
             -o "HostKeyAlgorithms $(ssh -Q key | tr '\n' ',' | head -c -1)" \
-            demo@localhost -p 2222 echo "Hello from \$(whoami)@\$(hostname)"
+            demo@localhost -p 2222 echo "Hello from \$(whoami)@\$(cat /etc/hostname)"
           docker stop target
 
       - name: Publish Docker image


### PR DESCRIPTION
## What
This PR fixes the output of the container test for e.g. https://github.com/greenbone/vt-test-environments/actions/runs/4185410682/jobs/7252429292#step:6:20.

## Why
No all distributions come with `hostname`, so the hostname will be blank then:
```
[...]
Warning: Permanently added '[localhost]:2222' (ED25519) to the list of known hosts.
bash: line 1: hostname: command not found
Hello from demo@
[...]
```

We can easily work around this by `cat`ing the file directly.

## References

<!-- Add links to issue tickets, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


