### PR TITLE
Add build and readme for Ubuntu 23.04 Lunar Lobster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,6 +217,8 @@ jobs:
             TAG: "22.04"
           - CONTEXT: operating_systems/ubuntu
             TAG: "22.10"
+          - CONTEXT: operating_systems/ubuntu
+            TAG: "23.04"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ When done, the container can be stopped with `docker stop target`.
     - `21.10` (Impish Indri)
     - `22.04` (LTS, Jammy Jellyfish)
     - `22.10` (Kinetic Kudu)
+    - `23.04` (Lunar Lobster)
 
 ## Build
 To build e.g. the image for Mageia 8 use:


### PR DESCRIPTION
## What

Adding ubuntu 23.04 (Lunar Lobster) to the repo.

- OS detection works
- Package detection works

See test output below.

## Why

Closes: VTA-428

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


