### PR TITLE
Temporarily disable Debian Jessie and Stretch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,11 @@ jobs:
           - CONTEXT: operating_systems/debian
             BASEIMAGE: debian/eol
             TAG: wheezy
-          - CONTEXT: operating_systems/debian
-            BASEIMAGE: debian/eol
-            TAG: jessie
-          - CONTEXT: operating_systems/debian
-            TAG: stretch
+          # - CONTEXT: operating_systems/debian
+          #   BASEIMAGE: debian/eol
+          #   TAG: jessie
+          # - CONTEXT: operating_systems/debian
+          #   TAG: stretch
           - CONTEXT: operating_systems/debian
             TAG: buster
           - CONTEXT: operating_systems/debian


### PR DESCRIPTION
## What
This PR disables the build of images for Debian Jessie and Stretch, until the underlying issue is fixed.

## Why
The build is [failing](https://github.com/greenbone/vt-test-environments/actions/runs/4959464632) because of https://github.com/debuerreotype/docker-debian-eol-artifacts/issues/8.
We could also fix this on our side, but that's probably not worth it.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


