### PR TITLE
Fix package write permissions in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What
This PR fixes the insufficient package write permissions in the build workflow, see https://github.com/greenbone/vt-test-environments/actions/runs/4979904780.

## Why
To be able to push images again. 

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


