### PR TITLE
Fix Home Assistant build

### DIFF
--- a/applications/home-assistant/Dockerfile
+++ b/applications/home-assistant/Dockerfile
@@ -2,7 +2,8 @@ ARG BASEIMAGE=homeassistant/home-assistant
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
-RUN apk add --no-cache openssh \
+RUN apk del openssh-client \
+    && apk add --no-cache openssh \
     && adduser -D demo \
     && echo "demo:demo" | chpasswd \
     && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" \


### PR DESCRIPTION
## What
This PR fixes the build of the Home Assistant image.

It's cause by `openssh-client` being already installed and `openssh` (that's client + server) conflicting with it. After removing the former, the latter can be installed without issues.

## Why
To have it building again and get rid off the red X on the build workflow.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


