### PR TITLE
Add generic container image

### DIFF
--- a/applications/generic/Dockerfile
+++ b/applications/generic/Dockerfile
@@ -1,0 +1,30 @@
+ARG BASEIMAGE
+ARG TAG
+
+FROM ghcr.io/greenbone/vt-test-environments/${BASEIMAGE}:${TAG}
+ARG UPDATED=true
+ARG TAG
+
+# Install dependencies
+RUN apt-get update \
+    && if [ "$UPDATED" = true ]; then apt-get upgrade -y; fi \
+    && apt-get install -y apache2 php mariadb-server samba \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure Apache and PHP
+RUN sed -i "/^expose_php/s/=.*/= On/" /etc/php/*/apache2/php.ini \
+    && sed -i "/^ServerTokens/s/ .*/ Full/" /etc/apache2/conf-enabled/security.conf \
+    && echo '<?php echo("test"); ?>' > /var/www/html/index.php
+
+# Configure MariaDB
+RUN sed -i "/^bind-address/s/= .*/= */" /etc/mysql/mariadb.conf.d/50-server.cnf \
+    && service mariadb start || service mysql start \
+    && echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY 'password' WITH GRANT OPTION;" | mysql
+
+# Configure Samba
+RUN sed -i "/^\[global\]/a\   server min protocol = NT1" /etc/samba/smb.conf
+
+ADD init.sh /
+CMD [ "/init.sh" ]
+
+EXPOSE 80 139 445 3306

--- a/applications/generic/Dockerfile
+++ b/applications/generic/Dockerfile
@@ -27,4 +27,4 @@ RUN sed -i "/^\[global\]/a\   server min protocol = NT1" /etc/samba/smb.conf
 ADD init.sh /
 CMD [ "/init.sh" ]
 
-EXPOSE 80 139 445 3306
+EXPOSE 80 445 3306

--- a/applications/generic/README.md
+++ b/applications/generic/README.md
@@ -30,5 +30,7 @@ You can use any Debian-based baseimage from [vt-test-environments](https://githu
 For the example above, run:
 
 ```
-docker run --rm -it -p 80:80 -p 445:445 -p 2222:22 -p 3306:3306 generic:debian_trixie
+docker run --rm -it -p 2222:22 -p 80:80 -p 445:445 -p 3306:3306 generic:debian_trixie
 ```
+
+Note: In this example, I mapped all container ports to the host, except for port 22, which is mapped to port 2222 in the host.

--- a/applications/generic/README.md
+++ b/applications/generic/README.md
@@ -1,0 +1,34 @@
+
+# vt-test-environments/applications/generic
+
+This image contains generic services to test OS detection VTs. It's based on our Debian-based test images.
+
+## Services installed
+
+- `openssh-server` (port 22, inherited from the baseimage)
+- `apache2` (port 80)
+- `php`
+- `mariadb-server` (port 3306)
+- `samba` (port 139 and 445)
+
+## Build
+
+The Dockerfile requires two build arguments:
+- `BASEIMAGE`: The name of the baseimage to build upon
+- `TAG`: The tag of the baseimage to build upon
+
+For example, to build the generic test image for Debian trixie (`ghcr.io/greenbone/vt-test-environments/debian:trixie`) and save under `generic:debian_trixie` run:
+
+```
+docker build --pull --build-arg BASEIMAGE=debian --build-arg TAG=trixie applications/generic -t generic:debian_trixie
+```
+
+You can use any Debian-based baseimage from [vt-test-environments](https://github.com/orgs/greenbone/packages?repo_name=vt-test-environments).
+
+
+## Usage
+For the example above, run:
+
+```
+docker run --rm -it -p 80:80 -p 445:445 -p 2222:22 -p 3306:3306 generic:debian_trixie
+```

--- a/applications/generic/README.md
+++ b/applications/generic/README.md
@@ -9,7 +9,7 @@ This image contains generic services to test OS detection VTs. It's based on our
 - `apache2` (port 80)
 - `php`
 - `mariadb-server` (port 3306)
-- `samba` (port 139 and 445)
+- `samba` (port 445)
 
 ## Build
 

--- a/applications/generic/init.sh
+++ b/applications/generic/init.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+source /etc/os-release
+if (( VERSION_ID <= 10 ))
+then
+    service mysql start
+else
+    service mariadb start
+fi
+
+
+for service in ssh apache2 smbd
+do
+    service $service start
+done
+
+sleep infinity


### PR DESCRIPTION
## What
This PR adds a generic container test image.

## Why
To ease testing of OS detection VTs.

## References
Jira: VTA-494

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


