### PR TITLE
Add openEuler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,22 @@ jobs:
             TAG: "8"
           - CONTEXT: operating_systems/mageia
             TAG: "9"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "22.03-lts"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "22.03-lts-sp1"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "22.03-lts-sp2"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "22.03-lts-sp3"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "22.03-lts-sp4"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "23.03"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "23.09"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "24.03-lts"
           - CONTEXT: operating_systems/oraclelinux
             TAG: "5"
             UPDATED: false

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ When done, the container can be stopped with `docker stop target`.
     - `7`
     - `8`
     - `9`
+- [openEuler](https://ghcr.io/greenbone/vt-test-environments/openeuler) (`openeuler`)
+    - `22.03-lts`
+    - `22.03-lts-sp1`
+    - `22.03-lts-sp2`
+    - `22.03-lts-sp3`
+    - `22.03-lts-sp4`
+    - `23.03`
+    - `23.09`
+    - `24.03-lts`
 - [Oracle Linux](https://ghcr.io/greenbone/vt-test-environments/oraclelinux) (`oraclelinux`)
     - `5`
     - `6`

--- a/operating_systems/openeuler/Dockerfile
+++ b/operating_systems/openeuler/Dockerfile
@@ -1,0 +1,18 @@
+ARG BASEIMAGE=openeuler/openeuler
+ARG TAG
+
+FROM ${BASEIMAGE}:${TAG}
+ARG UPDATED=true
+
+RUN if [ "$UPDATED" = true ]; then dnf upgrade -y; fi \
+    && dnf install -y openssh-server passwd \
+    && dnf clean all \
+    && useradd demo \
+    && echo "demo" | passwd --stdin demo \
+    && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" \
+    && ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" \
+    && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""
+
+CMD [ "/usr/sbin/sshd", "-D" ]
+
+EXPOSE 22


### PR DESCRIPTION
## What
This PR adds container images for openEuler.
I chose the latest ones from https://hub.docker.com/r/openeuler/openeuler, until the previous LTS release except for 22.09 (that one would need additional adjustments).

## Why
To have them available for testing.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


