### PR TITLE
Add: Missing EXPOSE to Oracle and RHEL Dockerfiles

### DIFF
--- a/operating_systems/oraclelinux/Dockerfile
+++ b/operating_systems/oraclelinux/Dockerfile
@@ -12,3 +12,5 @@ RUN if [ "$UPDATED" = true ]; then yum upgrade -y && yum clean all; fi \
     && (ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" || true)
 
 CMD [ "/usr/sbin/sshd", "-D" ]
+
+EXPOSE 22

--- a/operating_systems/rhel/Dockerfile
+++ b/operating_systems/rhel/Dockerfile
@@ -20,3 +20,5 @@ RUN if [ "$UPDATED" = true ]; then \
     && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""
 
 CMD [ "/usr/sbin/sshd", "-D" ]
+
+EXPOSE 22


### PR DESCRIPTION
## What
@cfi-gb noticed that two Dockerfiles were missing the `EXPOSE` statement. I can confirm his findings:
```
➜  vt-test-environments git:(main) rg -g Dockerfile --files-without-match EXPOSE
operating_systems/rhel/Dockerfile
operating_systems/oraclelinux/Dockerfile
```

## Why
Because it should be in there, but looks like we missed it.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


