### PR TITLE
Change: Extend CODEOWNERS file with automation team specific group.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default reviewers
-*                 @greenbone/vulnerability-test-maintainers @greenbone/scanner-maintainers
+*                 @greenbone/vt-automation-maintainers @greenbone/scanner-maintainers @greenbone/vulnerability-test-maintainers


### PR DESCRIPTION
## What
See title

## Why
While the automation team members are also in the vt team group this repo is mainly managed by the first team and this change makes this a little bit more clear / visible

## References
N/A