### PR TITLE
Change: Disable Slackware:current build due to failures.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,8 +215,11 @@ jobs:
             TAG: "14.2"
           - CONTEXT: operating_systems/slackware
             TAG: "15.0"
-          - CONTEXT: operating_systems/slackware
-            TAG: current
+          # nb: Disabled as this currently fails with errors like e.g. the following when building the image:
+          # more: error while loading shared libraries: liblz.so.1: cannot open shared object file: No such file or directory
+          # ssh-keygen: /lib64/libc.so.6: version `GLIBC_2.38' not found (required by ssh-keygen)
+          #- CONTEXT: operating_systems/slackware
+          #  TAG: current
           - CONTEXT: operating_systems/ubuntu
             TAG: "10.04"
           - CONTEXT: operating_systems/ubuntu

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ When done, the container can be stopped with `docker stop target`.
   - `14.1`
   - `14.2`
   - `15.0`
-  - `current` (15.0+ at the moment)
+  - `current` (15.0+ at the moment but currently disabled due to build failures)
 - [Ubuntu](https://ghcr.io/greenbone/vt-test-environments/ubuntu) (`ubuntu`)
   - `10.04` (LTS, Lucid Lynx)
   - `12.04` (LTS, Precise Pangolin)


### PR DESCRIPTION
## What
This might be an issue of the base image as we can see e.g. the following errors during build even if the image was updated fully:

```
more: error while loading shared libraries: liblz.so.1: cannot open shared object file: No such file or directory
*snip*
ssh-keygen: /lib64/libc.so.6: version `GLIBC_2.38' not found (required by ssh-keygen)
```

Until some one finds the issue / a solution just disabling the build for now.

## Why
Reducing "noise" in PRs with failed checks unrelated to the PR itself

## References
N/A