### PR TITLE
Change: Fix Slackware current

### DIFF
--- a/operating_systems/slackware/Dockerfile
+++ b/operating_systems/slackware/Dockerfile
@@ -4,10 +4,10 @@ ARG TAG
 FROM ${BASEIMAGE}:${TAG}
 ARG UPDATED=true
 
-RUN echo "Y" | slackpkg update \
+RUN slackpkg update \
     # When updating, we need to upgrade slackpkg itself first. Otherwise upgrade-all will abort
     # We can skip this steps, if slackpkg or all packages are already up-to-date
-    && if [ "$UPDATED" = true ]; then slackpkg upgrade slackpkg || slackpkg upgrade-all || true; fi \
+    && if [ "$UPDATED" = true ]; then slackpkg upgrade slackpkg && slackpkg upgrade-all || true && slackpkg upgrade-all; fi \
     && slackpkg install openssh \
     && rm -rf /var/lib/slackpkg/* \
     && useradd demo \

--- a/operating_systems/slackware/Dockerfile
+++ b/operating_systems/slackware/Dockerfile
@@ -5,8 +5,9 @@ FROM ${BASEIMAGE}:${TAG}
 ARG UPDATED=true
 
 RUN slackpkg update \
-    # When updating, we need to upgrade slackpkg itself first. Otherwise upgrade-all will abort
-    # We can skip this steps, if slackpkg or all packages are already up-to-date
+    # When updating, we need to upgrade slackpkg itself first. Otherwise upgrade-all will abort.
+    # We can skip this steps, if slackpkg or all packages are already up-to-date.
+    # slackpkg upgrade also needs to be called twice, because some packages might fail in the first run, which work in the second.
     && if [ "$UPDATED" = true ]; then slackpkg upgrade slackpkg && slackpkg upgrade-all || true && slackpkg upgrade-all; fi \
     && slackpkg install openssh \
     && rm -rf /var/lib/slackpkg/* \


### PR DESCRIPTION
## What
This PR fixes the build of Slackware current.

## Why
Because it's failing due to an outdated libc. Updating is was a little tricky, because at some point in the installation of packages failed due to some GPG issues (gnupg has been updated right before).
I tried several approaches, but only running `upgrade-all` twice (allowing failure only in the first run, then fixing those in the second) was reliable.

## References
This makes https://github.com/greenbone/vt-test-environments/pull/62 obsolete.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


