### PR TITLE
Change: Use --no-install-recommends for Debian/Ubuntu to reduce image size.

### DIFF
--- a/applications/oracle-weblogic/10.3.6.0-2017/Dockerfile
+++ b/applications/oracle-weblogic/10.3.6.0-2017/Dockerfile
@@ -12,7 +12,7 @@ RUN ( \
     if [ $? = 100 ]; then sed -i "s/security\|archive/old-releases/" /etc/apt/sources.list && apt-get update; fi \
     ) \
     && if [ "$UPDATED" = true ]; then apt-get upgrade -y; fi \
-    && apt-get install -y openssh-server \
+    && apt-get install --no-install-recommends -y openssh-server \
     && rm -rf /var/lib/apt/lists/* \
     && useradd demo \
     && echo "demo:demo" | chpasswd \

--- a/operating_systems/debian/Dockerfile
+++ b/operating_systems/debian/Dockerfile
@@ -8,7 +8,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && if [ "$UPDATED" = true ]; then apt-get upgrade -y; fi \
     && if [ $(cut -d "." -f 1 /etc/debian_version) -lt 4 ]; then apt-get install -y ssh; \
-    else apt-get install -y openssh-server; fi \
+    elif [ $(cut -d "." -f 1 /etc/debian_version) -eq 4 ]; then apt-get install -y openssh-server; \
+    else apt-get install --no-install-recommends -y openssh-server; fi \
     && rm -rf /var/lib/apt/lists/* \
     && useradd demo \
     && echo "demo:demo" | chpasswd \

--- a/operating_systems/ubuntu/Dockerfile
+++ b/operating_systems/ubuntu/Dockerfile
@@ -12,7 +12,7 @@ RUN ( \
     if [ $? = 100 ]; then sed -i "s/security\|archive/old-releases/" /etc/apt/sources.list && apt-get update; fi \
     ) \
     && if [ "$UPDATED" = true ]; then apt-get upgrade -y; fi \
-    && apt-get install -y openssh-server \
+    && apt-get install --no-install-recommends -y openssh-server \
     && rm -rf /var/lib/apt/lists/* \
     && useradd demo \
     && echo "demo:demo" | chpasswd \


### PR DESCRIPTION
## What

https://packages.debian.org/bookworm/openssh-server has various `rec` dependencies to e.g. `xauth` which pulls in various (for us / our purposes) unnecessary X11 dependencies. After this change the image size got reduced from:

```
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
debian       12        bbd0a7b950d6   39 seconds ago   190MB
```

to:

```
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
debian       12        cc5a6cc10e13   27 seconds ago   162MB
```

without any functional limitations.

Note: Ubuntu failures seems to be unrelated to this PR and might be related to VTA-589

## Why

Reduce size of our images a little.

## References

None

## Checklist

- [x] Tests