### PR TITLE
Change: Build Ubuntu 24.10 image.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,6 +269,8 @@ jobs:
             TAG: "23.10"
           - CONTEXT: operating_systems/ubuntu
             TAG: "24.04"
+          - CONTEXT: operating_systems/ubuntu
+            TAG: "24.10"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## What

See title

## Why

24.10 has been already released on October 10, 2024 but not build yet, this should change.

## References

None