### PR TITLE
Refactor image building (e.g. using Buildah instead of Docker)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,7 +304,7 @@ jobs:
 
       - name: Test Docker image
         run: |
-          podman run --rm -d --name target -p 2222:22 ${{ env.IMAGE }}:${{ env.TAG }}
+          podman run --rm -d --name target -p 2222:22 ${{ env.IMAGE }}
           sshpass -p demo ssh \
             -o "StrictHostKeyChecking no" \
             -o "KexAlgorithms $(ssh -Q kex | tr '\n' ',' | head -c -1)" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Login to Docker Registry
-        uses: docker/login-action@v3
+        uses: redhat-actions/podman-login@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -295,29 +295,25 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: redhat-actions/buildah-build@v2
         with:
           context: ${{ matrix.CONTEXT }}
-          load: true
           tags: ${{ env.IMAGE }}
           build-args: ${{ env.BUILD_ARGS }}
 
       - name: Test Docker image
         run: |
-          docker run --rm -d --name target -p 2222:22 ${{ env.IMAGE }}
+          podman run --rm -d --name target -p 2222:22 ${{ env.IMAGE }}:${{ env.TAG }}
           sshpass -p demo ssh \
             -o "StrictHostKeyChecking no" \
             -o "KexAlgorithms $(ssh -Q kex | tr '\n' ',' | head -c -1)" \
             -o "Ciphers $(ssh -Q ciphers | tr '\n' ',' | head -c -1)" \
             -o "HostKeyAlgorithms $(ssh -Q key | tr '\n' ',' | head -c -1)" \
             demo@localhost -p 2222 echo "Hello from \$(whoami)@\$(cat /etc/hostname)"
-          docker stop target
+          podman stop target
 
       - name: Publish Docker image
-        uses: docker/build-push-action@v6
+        uses: redhat-actions/push-to-registry@v2
         if: ${{ github.event_name == 'push' }}
         with:
-          context: ${{ matrix.CONTEXT }}
-          push: true
           tags: ${{ env.IMAGE }}
-          build-args: ${{ env.BUILD_ARGS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,7 @@ jobs:
             TAG: "15.0"
           - CONTEXT: operating_systems/slackware
             TAG: current
+            UPDATED: true
           - CONTEXT: operating_systems/ubuntu
             TAG: "10.04"
           - CONTEXT: operating_systems/ubuntu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,6 +298,7 @@ jobs:
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
           context: ${{ matrix.CONTEXT }}
+          containerfiles: ${{ matrix.CONTEXT }}/Dockerfile
           tags: ${{ env.IMAGE }}
           build-args: ${{ env.BUILD_ARGS }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,9 +273,9 @@ jobs:
             TAG: "24.10"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Login to Docker Registry
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -295,7 +295,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Build Docker image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
           context: ${{ matrix.CONTEXT }}
           tags: ${{ env.IMAGE }}
@@ -313,7 +313,7 @@ jobs:
           podman stop target
 
       - name: Publish Docker image
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         if: ${{ github.event_name == 'push' }}
         with:
           tags: ${{ env.IMAGE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,6 @@ jobs:
             TAG: "24.03-lts"
           - CONTEXT: operating_systems/oraclelinux
             TAG: "5"
-            UPDATED: false
           - CONTEXT: operating_systems/oraclelinux
             TAG: "6"
           - CONTEXT: operating_systems/oraclelinux
@@ -136,59 +135,45 @@ jobs:
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi7
             TAG: "7.6"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi7
             TAG: "7.7"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi7
             TAG: "7.8"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi7
             TAG: "7.9"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi8
             TAG: "8.0"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi8
             TAG: "8.1"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi8
             TAG: "8.2"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi8
             TAG: "8.3"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi8
             TAG: "8.4"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi8
             TAG: "8.5"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi8
             TAG: "8.6"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi8
             TAG: "8.7"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi9
             TAG: "9.0.0"
-            UPDATED: false
           - CONTEXT: operating_systems/rhel
             BASEIMAGE: registry.access.redhat.com/ubi9
             TAG: "9.1.0"
-            UPDATED: false
           - CONTEXT: operating_systems/rockylinux
             TAG: "8.5"
           - CONTEXT: operating_systems/rockylinux

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Dependency Review'
-        uses: greenbone/actions/dependency-review@v3
+        uses: greenbone/actions/dependency-review@a1883bd24d2d921426b3f06413e84606ecd43bdd # v3.27.11

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -11,4 +11,4 @@ jobs:
       contents: write
     steps:
       - name: 'SBOM upload'
-        uses: greenbone/actions/sbom-upload@v3
+        uses: greenbone/actions/sbom-upload@a1883bd24d2d921426b3f06413e84606ecd43bdd # v3.27.11

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ To build e.g. the image for Mageia 8 use:
 docker build operating_systems/mageia --build-arg=TAG=8 -t mageia:8
 ```
 
-If not specified otherwise, the image will be built with its packages explicitly updated. This is available for most images. To build the image for Oracle Linux 5 (non-updated) use:
+If not specified otherwise, the image will be built with its packages explicitly not updated. This is available for most images. To build the image for Oracle Linux 5 (updated) use:
 
 ```
-docker build operating_systems/oraclelinux --build-arg=TAG=5 --build-arg=UPDATED=false -t oraclelinux:5
+docker build operating_systems/oraclelinux --build-arg=TAG=5 --build-arg=UPDATED=true -t oraclelinux:5
 ```

--- a/applications/generic/Dockerfile
+++ b/applications/generic/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE
 ARG TAG
 
 FROM ghcr.io/greenbone/vt-test-environments/${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 ARG TAG
 
 # Install dependencies

--- a/applications/home-assistant/Dockerfile
+++ b/applications/home-assistant/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=homeassistant/home-assistant
+ARG BASEIMAGE=docker.io/homeassistant/home-assistant
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}

--- a/applications/oracle-weblogic/10.3.6.0-2017/Dockerfile
+++ b/applications/oracle-weblogic/10.3.6.0-2017/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=vulhub/weblogic
+ARG BASEIMAGE=docker.io/vulhub/weblogic
 ARG TAG=10.3.6.0-2017
 
 FROM ${BASEIMAGE}:${TAG}

--- a/applications/oracle-weblogic/10.3.6.0-2017/Dockerfile
+++ b/applications/oracle-weblogic/10.3.6.0-2017/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=vulhub/weblogic
 ARG TAG=10.3.6.0-2017
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN ( \

--- a/applications/oracle-weblogic/12.2.1.3-2018/Dockerfile
+++ b/applications/oracle-weblogic/12.2.1.3-2018/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=vulhub/weblogic
+ARG BASEIMAGE=docker.io/vulhub/weblogic
 ARG TAG=12.2.1.3-2018
 
 FROM ${BASEIMAGE}:${TAG}

--- a/applications/oracle-weblogic/12.2.1.3-2018/Dockerfile
+++ b/applications/oracle-weblogic/12.2.1.3-2018/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=vulhub/weblogic
 ARG TAG=12.2.1.3-2018
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 
 USER root
 

--- a/operating_systems/almalinux/Dockerfile
+++ b/operating_systems/almalinux/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=almalinux
+ARG BASEIMAGE=docker.io/library/almalinux
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}

--- a/operating_systems/almalinux/Dockerfile
+++ b/operating_systems/almalinux/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=almalinux
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 ARG TAG
 
 # Lock releasever to the tag to pin the minor release

--- a/operating_systems/amazonlinux/Dockerfile
+++ b/operating_systems/amazonlinux/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=amazonlinux
+ARG BASEIMAGE=docker.io/library/amazonlinux
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}

--- a/operating_systems/amazonlinux/Dockerfile
+++ b/operating_systems/amazonlinux/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=amazonlinux
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 
 RUN if [ "$UPDATED" = true ]; then yum upgrade -y; fi \
     && yum install -y openssh-server passwd \

--- a/operating_systems/debian/Dockerfile
+++ b/operating_systems/debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=debian
+ARG BASEIMAGE=docker.io/library/debian
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}

--- a/operating_systems/debian/Dockerfile
+++ b/operating_systems/debian/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=debian
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/operating_systems/euleros/Dockerfile
+++ b/operating_systems/euleros/Dockerfile
@@ -1,5 +1,5 @@
 # Don't use anything RHEL 9-based. It'll break the RPM GPG key.
-FROM rockylinux:8.6 as builder
+FROM docker.io/library/rockylinux:8.6 as builder
 
 ARG TAG
 WORKDIR /tmp

--- a/operating_systems/fedora/Dockerfile
+++ b/operating_systems/fedora/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=fedora
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 
 RUN if [ "$UPDATED" = true ]; then dnf upgrade -y; fi \
     && dnf install -y openssh-server \

--- a/operating_systems/fedora/Dockerfile
+++ b/operating_systems/fedora/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=fedora
+ARG BASEIMAGE=docker.io/library/fedora
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}

--- a/operating_systems/mageia/Dockerfile
+++ b/operating_systems/mageia/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=mageia
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 
 RUN if [ "$UPDATED" = true ]; then dnf upgrade -y; fi \
     && dnf install -y openssh-server \

--- a/operating_systems/mageia/Dockerfile
+++ b/operating_systems/mageia/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=mageia
+ARG BASEIMAGE=docker.io/library/mageia
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}

--- a/operating_systems/openeuler/Dockerfile
+++ b/operating_systems/openeuler/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=openeuler/openeuler
+ARG BASEIMAGE=docker.io/openeuler/openeuler
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}

--- a/operating_systems/openeuler/Dockerfile
+++ b/operating_systems/openeuler/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=openeuler/openeuler
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 
 RUN if [ "$UPDATED" = true ]; then dnf upgrade -y; fi \
     && dnf install -y openssh-server passwd \

--- a/operating_systems/oraclelinux/Dockerfile
+++ b/operating_systems/oraclelinux/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=oraclelinux
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 
 RUN if [ "$UPDATED" = true ]; then yum upgrade -y && yum clean all; fi \
     && useradd demo \

--- a/operating_systems/oraclelinux/Dockerfile
+++ b/operating_systems/oraclelinux/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=oraclelinux
+ARG BASEIMAGE=docker.io/library/oraclelinux
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}

--- a/operating_systems/rockylinux/Dockerfile
+++ b/operating_systems/rockylinux/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=rockylinux
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 ARG TAG
 
 # Lock releasever to the tag to pin the minor release

--- a/operating_systems/rockylinux/Dockerfile
+++ b/operating_systems/rockylinux/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=rockylinux
+ARG BASEIMAGE=docker.io/library/rockylinux
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}

--- a/operating_systems/slackware/Dockerfile
+++ b/operating_systems/slackware/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=vbatts/slackware
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 
 RUN slackpkg update \
     # When updating, we need to upgrade slackpkg itself first. Otherwise upgrade-all will abort.

--- a/operating_systems/slackware/Dockerfile
+++ b/operating_systems/slackware/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=vbatts/slackware
+ARG BASEIMAGE=docker.io/vbatts/slackware
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}

--- a/operating_systems/ubuntu/Dockerfile
+++ b/operating_systems/ubuntu/Dockerfile
@@ -2,7 +2,7 @@ ARG BASEIMAGE=ubuntu
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
-ARG UPDATED=true
+ARG UPDATED=false
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN ( \

--- a/operating_systems/ubuntu/Dockerfile
+++ b/operating_systems/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASEIMAGE=ubuntu
+ARG BASEIMAGE=docker.io/library/ubuntu
 ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}


### PR DESCRIPTION
## What
This PR
- changes Docker with Podman / Buildah to build, test and push our images (fixes currently broken workflow)
- disables updating of images by default
- includes the registry in the baseimage name
- pins our workflow dependencies.

## Why
Docker dropped support for Docker Image Format v1 and Docker Image manifest version 2, schema 1. Old images, like we are depending on in this repo, are still using those deprecated versions though. Buildah / Podman still have support for those.
If those older images are converted to version 2, schema 2 at some point, we could go back to Docker.

I also disabled the updating of images by default. My intention back then was to provide mostly up-to-date images, but we actually want rather non-update / vulnerable images in this repo. Besides that, updating the images lead to build issues in the past.

Including the registry in the baseimage is is good idea, because we then explicitly instead of implicitly use Docker Hub. Buildah / Podman might use other registries instead otherwise.

Pinning the workflow dependencies as been done, as requested by DevOps / generally a good idea. 

## References
Fixes VTA-589

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


