### PR TITLE
Change: Reduce RHEL image size by calling "yum clean all" after installing packages.

### DIFF
--- a/operating_systems/rhel/Dockerfile
+++ b/operating_systems/rhel/Dockerfile
@@ -9,10 +9,9 @@ RUN if [ "$UPDATED" = true ]; then \
     # Pinning minor version is impossible because of missing separate repository.
     # Workaround: Exclude release files (e.g. /etc/os-release)
     # for RHEL 7 and RHEL 8 or higher, respectively
-    yum upgrade -y --exclude redhat-release-server --exclude redhat-release \
-    && yum clean all; \
-    fi \
+    yum upgrade -y --exclude redhat-release-server --exclude redhat-release; fi \
     && yum install -y openssh-server \
+    && yum clean all \
     && useradd demo \
     && echo "demo" | passwd --stdin demo \
     && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" \


### PR DESCRIPTION
## What

`yum clean all` was only called before the installation of additional packages and only in the case if `UPDATED=true` was used.

Before this change:

```
$ docker image ls rhel:8.7
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
rhel         8.7       4cc316416a53   11 seconds ago   234MB
```

after this change:

```
$ docker image ls rhel:8.7
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
rhel         8.7       ade26e58d71d   7 seconds ago   225MB
```

## Why
Reduce image size (not much but still worth a minor change like this)

## References
None

## Checklist
- [x] Tests