### PR TITLE
Change: Fix Oracle Weblogic image tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,7 +271,7 @@ jobs:
 
       - name: Prepare environment variables
         run: |
-          echo "IMAGE=ghcr.io/${{ github.repository }}/$(basename ${{ matrix.CONTEXT }}):${{ matrix.TAG }}" >> $GITHUB_ENV
+          echo "IMAGE=ghcr.io/${{ github.repository }}/$(echo ${{ matrix.CONTEXT }} | cut -d / -f 2):${{ matrix.TAG }}" >> $GITHUB_ENV
           echo "BUILD_ARGS<<EOF" >> $GITHUB_ENV
           echo "TAG=${{ matrix.TAG }}" >> $GITHUB_ENV
           if [[ -n "${{ matrix.BASEIMAGE }}" ]]; then


### PR DESCRIPTION
## What
This PR fixes the Oracle Weblogic image tag.

## Why
Because it currently gets published as e.g. `ghcr.io/greenbone/vt-test-environments/10.3.6.0-2017:10.3.6.0-2017` instead of `ghcr.io/greenbone/vt-test-environments/oracle-weblogic:10.3.6.0-2017`.

## References
This issue was introduced in https://github.com/greenbone/vt-test-environments/pull/60.

## Checklist
I checked that the Oracle images are now built with `tags: ghcr.io/greenbone/vt-test-environments/oracle-weblogic:12.2.1.3-2018` instead of `tags: ghcr.io/greenbone/vt-test-environments/12.2.1.3-2018:12.2.1.3-2018`.
I also checked a few other images to confirm that they're still built with the same tag.