### PR TITLE
Add: openEuler-20.03-LTS/-SP versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,16 @@ jobs:
           - CONTEXT: operating_systems/mageia
             TAG: "9"
           - CONTEXT: operating_systems/openeuler
+            TAG: "20.03-lts"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "20.03-lts-sp1"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "20.03-lts-sp2"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "20.03-lts-sp3"
+          - CONTEXT: operating_systems/openeuler
+            TAG: "20.03-lts-sp4"
+          - CONTEXT: operating_systems/openeuler
             TAG: "22.03-lts"
           - CONTEXT: operating_systems/openeuler
             TAG: "22.03-lts-sp1"

--- a/operating_systems/openeuler/Dockerfile
+++ b/operating_systems/openeuler/Dockerfile
@@ -3,9 +3,13 @@ ARG TAG
 
 FROM ${BASEIMAGE}:${TAG}
 ARG UPDATED=false
+ARG TAG
 
+RUN if [ "$TAG" = "20.03-lts" ]; then dnf install -y \
+    https://repo.openeuler.org/openEuler-20.03-LTS/update/x86_64/Packages/openEuler-gpg-keys-1.0-2.9.oe1.x86_64.rpm \
+    https://repo.openeuler.org/openEuler-20.03-LTS/update/x86_64/Packages/openEuler-repos-1.0-2.9.oe1.x86_64.rpm; fi
 RUN if [ "$UPDATED" = true ]; then dnf upgrade -y; fi \
-    && dnf install -y openssh-server passwd \
+    && dnf install -y openssh-server passwd shadow-utils\
     && dnf clean all \
     && useradd demo \
     && echo "demo" | passwd --stdin demo \


### PR DESCRIPTION
## What
Adds the openEuler 20.03 LTS/SP containers to the workflow.
The openEuler-20.03-lts base container does not have a package repository configured.  To fix this, the gpg key and repo package will be installed if the container to be created is 20.03-lts.
Useradd is also missing, so shadow-utils is installed.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


