### PR TITLE
Changes: Added support for openSUSE tumbleweed and leap v15.6,v15.5,v…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,24 @@ jobs:
             TAG: "24.03-lts"
           - CONTEXT: operating_systems/openeuler
             TAG: "24.09"
+          - CONTEXT: operating_systems/opensuse
+            BASEIMAGE: opensuse/leap
+            TAG: "15.6"
+          - CONTEXT: operating_systems/opensuse
+            BASEIMAGE: opensuse/leap
+            TAG: "15.5"
+          - CONTEXT: operating_systems/opensuse
+            BASEIMAGE: opensuse/leap
+            TAG: "15.4"
+          - CONTEXT: operating_systems/opensuse
+            BASEIMAGE: opensuse/leap
+            TAG: "15.3"
+          - CONTEXT: operating_systems/opensuse
+            BASEIMAGE: opensuse/leap
+            TAG: "15.3"
+          - CONTEXT: operating_systems/opensuse
+            BASEIMAGE: opensuse/tumbleweed
+            TAG: "latest"
           - CONTEXT: operating_systems/oraclelinux
             TAG: "5"
           - CONTEXT: operating_systems/oraclelinux

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ When done, the container can be stopped with `docker stop target`.
   - `23.09`
   - `24.03-lts`
   - `24.09`
+- [openSUSE](https://ghcr.io/greenbone/vt-test-environments/opensuse) (`opensuse`)
+  - `leap:15.6`
+  - `leap:15.5`
+  - `leap:15.4`
+  - `leap:15.3`
+  - `tumbleweed:latest`
 - [Oracle Linux](https://ghcr.io/greenbone/vt-test-environments/oraclelinux) (`oraclelinux`)
   - `5`
   - `6`

--- a/operating_systems/opensuse/Dockerfile
+++ b/operating_systems/opensuse/Dockerfile
@@ -1,0 +1,21 @@
+ARG BASEIMAGE=opensuse/leap
+ARG TAG=latest
+
+FROM ${BASEIMAGE}:${TAG}
+ARG UPDATED=false
+
+RUN if [ "$UPDATED" = true ]; then zypper refresh && zypper update -y; fi \
+    && zypper install -y openssh shadow \
+    && zypper clean \
+    && useradd -m demo \
+    && echo "demo:demo" | chpasswd \
+    && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" \
+    && (ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" || true) \
+    && (ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" || true) \
+    && [ ! -f /etc/ssh/sshd_config ] && /usr/sbin/sshd -t || true \
+    && touch /etc/ssh/sshd_config \
+    && echo "PasswordAuthentication yes" >> /etc/ssh/sshd_configc
+
+CMD [ "/usr/sbin/sshd", "-D" ]
+
+EXPOSE 22


### PR DESCRIPTION
…15.4,v15.3

## What
This PR adds container images for openSUSE.
Currently it is added for openSUSE Tumbleweed latest, because Tumbleweed is a rolling update hence there are no specific versions of it. However, for openSUSE Leap the following versions support has been added: 15.6,15.5,15.4,15.3

## Why
To make them available for testing

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


