### PR TITLE
Export images with different tags than their source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,7 +281,7 @@ jobs:
 
       - name: Prepare environment variables
         run: |
-          echo "IMAGE=ghcr.io/${{ github.repository }}/$(echo ${{ matrix.CONTEXT }} | cut -d / -f 2):${{ matrix.TAG }}" >> $GITHUB_ENV
+          echo "IMAGE=ghcr.io/${{ github.repository }}/$(echo ${{ matrix.CONTEXT }} | cut -d / -f 2):${{ matrix.EXPORT_TAG || matrix.TAG }}" >> $GITHUB_ENV
           echo "BUILD_ARGS<<EOF" >> $GITHUB_ENV
           echo "TAG=${{ matrix.TAG }}" >> $GITHUB_ENV
           if [[ -n "${{ matrix.BASEIMAGE }}" ]]; then


### PR DESCRIPTION
## What
This PR adds the possibility to explicitly specify a tag for the exported image. If not specified, it'll keep using the tag of the source image.

## Why
For https://github.com/greenbone/vt-test-environments/pull/77 we need to use the image `tumbleweed:latest`, but want to export is as `opensuse:tumbleweed` instead. This is not possible with the current behavior.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
I tested this using two Ubuntu images in https://github.com/greenbone/vt-test-environments/actions/runs/12647975873?pr=79. 
Without any `EXPORT_TAG` the image us built using
```
Run redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056
  with:
    context: operating_systems/ubuntu
    containerfiles: operating_systems/ubuntu/Dockerfile
    tags: ghcr.io/greenbone/vt-test-environments/ubuntu:24.04
    build-args: TAG=24.04
[...]
✅ Successfully built image "ghcr.io/greenbone/vt-test-environments/ubuntu:24.04"
```
With it it's built using
```
Run redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056
  with:
    context: operating_systems/ubuntu
    containerfiles: operating_systems/ubuntu/Dockerfile
    tags: ghcr.io/greenbone/vt-test-environments/ubuntu:foo
    build-args: TAG=24.10
[...]
✅ Successfully built image "ghcr.io/greenbone/vt-test-environments/ubuntu:foo"
```