### PR TITLE
Work around broken SSH login by disabling PAM for Fedora and Oracle

### DIFF
--- a/operating_systems/fedora/Dockerfile
+++ b/operating_systems/fedora/Dockerfile
@@ -11,7 +11,9 @@ RUN if [ "$UPDATED" = true ]; then dnf upgrade -y; fi \
     && echo "demo:demo" | chpasswd \
     && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" \
     && ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" \
-    && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""
+    && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" \
+    # Workaround to fix SSH login (see VTA-641)
+    && echo "UsePAM no" > /etc/ssh/sshd_config.d/01-disable-usepam.conf
 
 CMD [ "/usr/sbin/sshd", "-D" ]
 

--- a/operating_systems/oraclelinux/Dockerfile
+++ b/operating_systems/oraclelinux/Dockerfile
@@ -9,7 +9,10 @@ RUN if [ "$UPDATED" = true ]; then yum upgrade -y && yum clean all; fi \
     && echo "demo" | passwd --stdin demo \
     && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" \
     && (ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" || true) \
-    && (ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" || true)
+    && (ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" || true) \
+    # Workaround to fix SSH login (see VTA-641)
+    && if [ -d /etc/ssh/sshd_config.d ]; then echo "UsePAM no" > /etc/ssh/sshd_config.d/01-disable-usepam.conf; \
+    else sed -i "s/UsePAM yes/UsePAM no/" /etc/ssh/sshd_config; fi
 
 CMD [ "/usr/sbin/sshd", "-D" ]
 


### PR DESCRIPTION
## What
This PR disables PAM for Fedora and Oracle.

## Why
Because the build for Fedora 40 and Oracle 8 & 9 are currently broken, because PAM during SSH authentication is not working correctly in Podman. See the Jira ticket for more information.
Disabling PAM is officially not supported in Fedora & Oracle, but I couldn't find anything broken for our use-case.

For Fedora and Oracle 9 I simply created an additional config file to disable PAM, for Oracle 8 (which doesn't use `.d`-config files by default) I edited the main config.

## References
Jira: https://jira.greenbone.net/browse/VTA-641

## Checklist
I've built the containers for Fedora 39 and 40 as well as Oracle 7, 8 and 9. They are working again / working as expected.