### PR TITLE
Fix openEuler 20.04-lts

### DIFF
--- a/operating_systems/openeuler/Dockerfile
+++ b/operating_systems/openeuler/Dockerfile
@@ -6,7 +6,7 @@ ARG UPDATED=false
 ARG TAG
 
 RUN if [ "$UPDATED" = true ]; then dnf upgrade -y; fi \
-    && dnf install -y openssh-server passwd shadow-utils\
+    && if [ "$TAG" != "20.03-lts" ]; dnf install -y openssh-server passwd shadow-utils; fi \
     && dnf clean all \
     && useradd demo \
     && echo "demo" | passwd --stdin demo \

--- a/operating_systems/openeuler/Dockerfile
+++ b/operating_systems/openeuler/Dockerfile
@@ -6,10 +6,10 @@ ARG UPDATED=false
 ARG TAG
 
 RUN if [ "$UPDATED" = true ]; then dnf upgrade -y; fi \
-    && if [ "$TAG" != "20.03-lts" ]; dnf install -y openssh-server passwd shadow-utils; fi \
+    && if [ "$TAG" != "20.03-lts" ]; then dnf install -y openssh-server; fi \
     && dnf clean all \
     && useradd demo \
-    && echo "demo" | passwd --stdin demo \
+    && echo "demo:demo" | chpasswd \
     && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" \
     && ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" \
     && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""

--- a/operating_systems/openeuler/Dockerfile
+++ b/operating_systems/openeuler/Dockerfile
@@ -5,9 +5,6 @@ FROM ${BASEIMAGE}:${TAG}
 ARG UPDATED=false
 ARG TAG
 
-RUN if [ "$TAG" = "20.03-lts" ]; then dnf install -y \
-    https://repo.openeuler.org/openEuler-20.03-LTS/update/x86_64/Packages/openEuler-gpg-keys-1.0-2.9.oe1.x86_64.rpm \
-    https://repo.openeuler.org/openEuler-20.03-LTS/update/x86_64/Packages/openEuler-repos-1.0-2.9.oe1.x86_64.rpm; fi
 RUN if [ "$UPDATED" = true ]; then dnf upgrade -y; fi \
     && dnf install -y openssh-server passwd shadow-utils\
     && dnf clean all \


### PR DESCRIPTION
## What
This PR fixes the build of the openEuler 20.03-lts image.

## Why
Do make it working again.

For whatever reason, installing `openssh-server` tries to downgrade `openssh` (a dependencies of `openssh-server`) to a version that isn't signed. This is why the build is failing.
Luckily, openEuler 20.03-lts already comes with a `openssh-server` preinstalled, so we can just skip the installation.
Installing only `openssh`, which for whatever reason depends in `openssh-server` would also solve the issue, but that'd be a little weird.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


