### PR TITLE
Update Debian images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
           - CONTEXT: operating_systems/debian
             TAG: stretch
           - CONTEXT: operating_systems/debian
+            BASEIMAGE: debian/eol
             TAG: buster
           - CONTEXT: operating_systems/debian
             TAG: bullseye

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,11 +69,11 @@ jobs:
           - CONTEXT: operating_systems/debian
             BASEIMAGE: debian/eol
             TAG: wheezy
-          # - CONTEXT: operating_systems/debian
-          #   BASEIMAGE: debian/eol
-          #   TAG: jessie
-          # - CONTEXT: operating_systems/debian
-          #   TAG: stretch
+          - CONTEXT: operating_systems/debian
+            BASEIMAGE: debian/eol
+            TAG: jessie
+          - CONTEXT: operating_systems/debian
+            TAG: stretch
           - CONTEXT: operating_systems/debian
             TAG: buster
           - CONTEXT: operating_systems/debian


### PR DESCRIPTION
## What
This PR updates three Debian images by re-enabling the build of Debian Jessie and Stretch and building Buster from `debian/eol`.

## Why
1. The underlying issue that required us to disable the builds for Jessie and Stretch has been resolved (see https://github.com/greenbone/vt-test-environments/pull/40 / https://github.com/debuerreotype/docker-debian-eol-artifacts/issues/8)
2. Although Debian Buster is still available in the main Debian repository, it'll be removed from there soon. It's already available in the archive and has a image in the EOL repository (see https://github.com/debuerreotype/docker-debian-eol-artifacts/commit/1f6f5e716896a64f66f85162f0b3fff65cc47538), so to prevent issue in the next months, we can already move it.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


