### PR TITLE
Change: Disable PAM for EulerOS to work around broken SSH login

### DIFF
--- a/operating_systems/euleros/Dockerfile
+++ b/operating_systems/euleros/Dockerfile
@@ -36,7 +36,9 @@ RUN echo "${TAG}" > /etc/yum/vars/releasever \
     # Generate SSH keys
     && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" \
     && ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -N "" \
-    && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""
+    && ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N "" \
+    # Workaround to fix SSH login (see VTA-641)
+    && sed -i "s/UsePAM yes/UsePAM no/" /etc/ssh/sshd_config
 
 CMD [ "/usr/sbin/sshd", "-D" ]
 


### PR DESCRIPTION
## What
This PR disables PAM for EulerOS, similar to https://github.com/greenbone/vt-test-environments/pull/82.

## Why
Because it's apparently also affected by https://jira.greenbone.net/browse/VTA-641, see https://github.com/greenbone/vt-test-environments/actions/runs/14055302493/job/39353400680#step:6:19.

## References
Relates to https://github.com/greenbone/vt-test-environments/pull/82 / https://jira.greenbone.net/browse/VTA-641.

## Checklist
Checked that EulerOS 2.9 is now working again.
