### PR TITLE
Add: Ubuntu 26.04 & Fedora 44

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ When done, the container can be stopped with `docker stop target`.
 - [Fedora](https://ghcr.io/greenbone/vt-test-environments/fedora) (`fedora`)
   - `39`
   - `40`
+  - `44`
 - [Mageia](https://ghcr.io/greenbone/vt-test-environments/mageia) (`mageia`)
   - `7`
   - `8`

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ When done, the container can be stopped with `docker stop target`.
   - `23.04` (Lunar Lobster)
   - `23.10` (Mantic Minotaur)
   - `24.04` (Noble Numbat)
+  - `26.04` (Resolute Raccoon)
 - [Alpine Linux](https://github.com/greenbone/vt-test-environments/pkgs/container/vt-test-environments/alpine) (`alpine`)
   - `3.19`
   - `3.20`

--- a/matrix.json
+++ b/matrix.json
@@ -41,6 +41,7 @@
   { "CONTEXT": "operating_systems/euleros", "TAG": "2.10" },
   { "CONTEXT": "operating_systems/fedora", "TAG": "39" },
   { "CONTEXT": "operating_systems/fedora", "TAG": "40" },
+  { "CONTEXT": "operating_systems/fedora", "TAG": "44" },
   { "CONTEXT": "operating_systems/mageia", "TAG": "7" },
   { "CONTEXT": "operating_systems/mageia", "TAG": "8" },
   { "CONTEXT": "operating_systems/mageia", "TAG": "9" },

--- a/matrix.json
+++ b/matrix.json
@@ -136,6 +136,7 @@
   { "CONTEXT": "operating_systems/ubuntu", "TAG": "23.10" },
   { "CONTEXT": "operating_systems/ubuntu", "TAG": "24.04" },
   { "CONTEXT": "operating_systems/ubuntu", "TAG": "24.10" },
+  { "CONTEXT": "operating_systems/ubuntu", "TAG": "26.04" },
   { "CONTEXT": "operating_systems/alpine", "TAG": "3.19" },
   { "CONTEXT": "operating_systems/alpine", "TAG": "3.20" },
   { "CONTEXT": "operating_systems/alpine", "TAG": "3.21" },


### PR DESCRIPTION
## What
This PR adds Ubuntu 26.04 and Fedora 44.

## Why
To have them available for testing.

## References
Related to https://jira.greenbone.net/browse/VTA-930 & https://jira.greenbone.net/browse/VTA-929.

## Checklist
I ran rather GPL.nasl against these two and both were detected as expected.
